### PR TITLE
Fixes #19 `LodashModuleReplacementPlugin` features

### DIFF
--- a/config/webpack.default.config.js
+++ b/config/webpack.default.config.js
@@ -150,7 +150,9 @@ function getConfig(opts) {
     },
     plugins: [
       new LodashModuleReplacementPlugin({
-        paths: true
+        paths: true,
+        collections: true,
+        shorthands: true
       }),
       new webpack.EnvironmentPlugin({ NODE_ENV: "development" }),
       new MiniCssExtractPlugin({ filename: config.cssFile }),


### PR DESCRIPTION
Fixes https://github.com/quintype/quintype-node-build/issues/19

BQ uses `collections` feature as most of the other publishers.
Added `shorthands` as most publishers using shorthands also.